### PR TITLE
Add an example ImageStream template 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,37 @@ be available for use.
 # Running the image Locally
 After building the image, you can run it locally using the following command: <br>
 `podman run -p 8080:8080 MY-CUSTOM-IMAGE:latest start-singleuser.sh --ip="0.0.0.0" --port=8080`
+
+## How to add the image to Open Data Hub/JupyterHub
+
+* Once you have pushed your image to an image registry that is accessible by your JupyterHub instance,
+you can use the `ImageStream` template in this repository at `openshift/oc-imagestream.yaml`.
+
+
+```yaml
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "true" # <-- setting it true makes it visible to ODH/JupyterHub
+  name: custom-notebook # <-- Update the ImageStream name here
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - from:
+      kind: DockerImage
+      name: quay.io/thoth-station/s2i-custom-notebook:latest # <-- Change to your container Image with tag
+    importPolicy:
+      scheduled: true
+    name: "latest"
+```
+
+* After updating the template file with your image details, you can run the following command to create a ImageStream in your JupyterHub Namespace:
+
+  `oc apply -f openshift/oc-imagestream.yaml -n MY_JUPYTERHuB_NAMESPACE`
+
+  *In OpenDataHub v0.5 or lower, the ImageStream name should have the following format: `s2i-XXXX-notebook`*
+
+* Once the ImageStream has been created, you might need to restart the JupyterHub pod for it see the newly added ImageStream.

--- a/openshift/oc-imagestream.yaml
+++ b/openshift/oc-imagestream.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "true" # <-- setting it true makes it visible to ODH/JupyterHub
+  name: custom-notebook # <-- Update the ImageStream name here
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - from:
+      kind: DockerImage
+      name: quay.io/thoth-station/s2i-custom-notebook:latest # <-- Change to your container Image with tag
+    importPolicy:
+      scheduled: true
+    name: "latest"


### PR DESCRIPTION
## Related Issues and Dependencies
#8 

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements
Adds a ImageStream template.
This template can be used to add newly built images to ODH/JupyterHub
Updates README instructions for using this added template.

<!--- Describe your changes in detail -->
