### PR TITLE
Add instructions for internal Datahub

### DIFF
--- a/aicoe/add-image-to-datahub.md
+++ b/aicoe/add-image-to-datahub.md
@@ -1,0 +1,10 @@
+# Import Container Image to Internal Datahub:
+
+1. Create a new ImageStream template, you can use [this template](https://github.com/AICoE/s2i-custom-notebook#how-to-add-the-image-to-open-data-hubjupyterhub).
+2. Fork this repo https://gitlab.cee.redhat.com/data-hub/dh-jupyterhub.
+3. Add a new ImageStream to the [bases/custom-images/jupyterhub-custom-images.yaml](https://gitlab.cee.redhat.com/data-hub/dh-jupyterhub/blob/master/bases/custom-images/jupyterhub-custom-images.yaml).
+4. And create a Merge Request to publish these changes to the internal DataHub instance.
+
+The newly created Merge Request will be then reviewed and tested by the DataHub team, and when after all the testing the merge request is merged, your notebook image should be available in the internal Datahub/Jupyterhub instance.
+
+You can look at one of our previous [Merge Requests](https://gitlab.cee.redhat.com/data-hub/dh-jupyterhub/merge_requests/27) to see what the process looks like.


### PR DESCRIPTION
## Related Issues and Dependencies

#8 

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Add markdown instructions for adding the created container image to the Internal DH instance
