### PR TITLE
Support Kerberos authentication

### DIFF
--- a/overlays/python38-internal/Dockerfile
+++ b/overlays/python38-internal/Dockerfile
@@ -11,6 +11,26 @@ ENV \
     # Path to be used in other layers to place s2i scripts into
     STI_SCRIPTS_PATH=/opt/app-root/builder
 
+USER root
+
+# Trust the Red Hat IT Root CA 
+RUN curl -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt --fail -L \
+         https://password.corp.redhat.com/RH-IT-Root-CA.crt \
+ && update-ca-trust extract
+ 
+RUN dnf install -y \
+    # runtime dependencies
+    krb5-workstation \
+    # development dependencies
+    krb5-devel \
+  # clean up
+  && dnf clean all
+
+# Install the Kerberos configuration
+COPY ./s2i/config/krb5.conf /etc
+
+USER default
+
 # rename thoth assemble and run scripts
 RUN mv /opt/app-root/builder/assemble /opt/app-root/builder/assemble.original
 RUN mv /opt/app-root/builder/run /opt/app-root/builder/run.original

--- a/overlays/python38-internal/Pipfile
+++ b/overlays/python38-internal/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+
+
+[requires]
+python_version = "3.8"

--- a/overlays/python38-internal/Pipfile.lock
+++ b/overlays/python38-internal/Pipfile.lock
@@ -1,0 +1,20 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "7f7606f08e0544d8d012ef4d097dabdd6df6843a28793eb6551245d4b2db4242"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.8"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {},
+    "develop": {}
+}

--- a/overlays/python38/Dockerfile
+++ b/overlays/python38/Dockerfile
@@ -11,6 +11,26 @@ ENV \
     # Path to be used in other layers to place s2i scripts into
     STI_SCRIPTS_PATH=/opt/app-root/builder
 
+USER root
+
+# Trust the Red Hat IT Root CA 
+RUN curl -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt --fail -L \
+         https://password.corp.redhat.com/RH-IT-Root-CA.crt \
+ && update-ca-trust extract
+ 
+RUN dnf install -y \
+    # runtime dependencies
+    krb5-workstation \
+    # development dependencies
+    krb5-devel \
+  # clean up
+  && dnf clean all
+
+# Install the Kerberos configuration
+COPY ./s2i/config/krb5.conf /etc
+
+USER default
+
 # rename thoth assemble and run scripts
 RUN mv /opt/app-root/builder/assemble /opt/app-root/builder/assemble.original
 RUN mv /opt/app-root/builder/run /opt/app-root/builder/run.original

--- a/s2i/config/krb5.conf
+++ b/s2i/config/krb5.conf
@@ -1,0 +1,30 @@
+# To opt out of the system crypto-policies configuration of krb5, remove the
+# symlink at /etc/krb5.conf.d/crypto-policies which will not be recreated.
+includedir /etc/krb5.conf.d/
+
+[logging]
+    default = FILE:/var/log/krb5libs.log
+    kdc = FILE:/var/log/krb5kdc.log
+    admin_server = FILE:/var/log/kadmind.log
+
+[libdefaults]
+    dns_lookup_realm = false
+    ticket_lifetime = 24h
+    renew_lifetime = 7d
+    forwardable = true
+    rdns = false
+    pkinit_anchors = FILE:/etc/pki/tls/certs/ca-bundle.crt
+    spake_preauth_groups = edwards25519
+    default_realm = REDHAT.COM
+    dns_canonicalize_hostname = fallback
+    
+[realms]
+ REDHAT.COM = {
+   kdc = kerberos.corp.redhat.com:88
+   admin_server = kerberos.corp.redhat.com:749
+   default_domain = redhat.com
+ }
+
+[domain_realm]
+ .redhat.com = REDHAT.COM
+ redhat.com = REDHAT.COM


### PR DESCRIPTION
Support Kerberos authentication
Signed-off-by: Alberto Falossi <afalossi@redhat.com>

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Updates the Python 3.8 based custom image `Dockerfile` to support Kerberos authentication

## Description

This PR extends the `Dockerfile` to install the dependencies to access Red Hat services via Kerberos. The `krb5.conf` overrides the default one with the settings for the Red Hat Kerberos realm.
