### PR TITLE
setting THAMOS_RUNTIME_ENVIRONMENT var for the proper use of custom notebook

### DIFF
--- a/overlays/elyra/Dockerfile
+++ b/overlays/elyra/Dockerfile
@@ -6,6 +6,7 @@ LABEL io.k8s.description="Custom JupyterHub Notebook Builder Image" \
       io.s2i.scripts-url=image:///opt/app-root/builder
 
 ENV \
+    THAMOS_RUNTIME_ENVIRONMENT="" \
     # DEPRECATED: Use above LABEL instead, because this will be removed in future versions.
     STI_SCRIPTS_URL=image:///opt/app-root/builder \
     # Path to be used in other layers to place s2i scripts into

--- a/overlays/python36/Dockerfile
+++ b/overlays/python36/Dockerfile
@@ -8,6 +8,7 @@ LABEL io.k8s.description="Custom JupyterHub Notebook Builder Image" \
       io.s2i.scripts-url=image:///opt/app-root/builder
 
 ENV \
+    THAMOS_RUNTIME_ENVIRONMENT="" \
     # DEPRECATED: Use above LABEL instead, because this will be removed in future versions.
     STI_SCRIPTS_URL=image:///opt/app-root/builder \
     # Path to be used in other layers to place s2i scripts into

--- a/overlays/python38-internal/Dockerfile
+++ b/overlays/python38-internal/Dockerfile
@@ -6,6 +6,7 @@ LABEL io.k8s.description="Custom JupyterHub Notebook Builder Image" \
       io.s2i.scripts-url=image:///opt/app-root/builder
 
 ENV \
+    THAMOS_RUNTIME_ENVIRONMENT="" \
     # DEPRECATED: Use above LABEL instead, because this will be removed in future versions.
     STI_SCRIPTS_URL=image:///opt/app-root/builder \
     # Path to be used in other layers to place s2i scripts into

--- a/overlays/python38/Dockerfile
+++ b/overlays/python38/Dockerfile
@@ -6,6 +6,7 @@ LABEL io.k8s.description="Custom JupyterHub Notebook Builder Image" \
       io.s2i.scripts-url=image:///opt/app-root/builder
 
 ENV \
+    THAMOS_RUNTIME_ENVIRONMENT="" \
     # DEPRECATED: Use above LABEL instead, because this will be removed in future versions.
     STI_SCRIPTS_URL=image:///opt/app-root/builder \
     # Path to be used in other layers to place s2i scripts into


### PR DESCRIPTION
setting THAMOS_RUNTIME_ENVIRONMENT var for the proper use of custom notebook
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

This env var is required for the proper build to happen when another repo uses the custom-notebook.